### PR TITLE
Parser test coverage

### DIFF
--- a/ui/encounter/src/app/complexity-parser/complexity-parser.service.spec.ts
+++ b/ui/encounter/src/app/complexity-parser/complexity-parser.service.spec.ts
@@ -46,12 +46,50 @@ describe('ComplexityParserService', () => {
       ];
       expect(service.parse(sourceCode)).toEqual(expctedReturn);
     });
-  });
 
-  it('Should return return block info from a block', ()=> {
-    const sourceCode = "{\nSysetm.out.println(\"Hello world\")\n}";
-    let expctedReturn: Block[] = [];
-    expect(service.parse(sourceCode)).toEqual(expctedReturn);
-  });
+    it('Should return return block info from a block', ()=> {
+      const sourceCode = "{\nSysetm.out.println(\"Hello world\")\n}";
+      let expctedReturn: Block[] = [];
+      expect(service.parse(sourceCode)).toEqual(expctedReturn);
+    });
 
+    it('Should return single while loop block information', ()=> {
+      const sourceCode = "int i = 0;\nwhile(i < N){\nSystem.out.print(\"Hello world\");\n}\nint z = i/2;";
+      let expctedReturn: Block[] = [
+        {
+          complexity: 1,
+          begLine: 2,
+          endLine: 4,
+          depth: 0
+        }
+      ];
+      expect(service.parse(sourceCode)).toEqual(expctedReturn);
+    });
+
+    it('Should return single do while block information', ()=> {
+      const sourceCode = "int i = 0;\ndo {\nSystem.out.print(\"Hello world\");\n}\nwhile(i < N);\nint z = i/2;";
+      let expctedReturn: Block[] = [
+        {
+          complexity: 1,
+          begLine: 2,
+          endLine: 4,
+          depth: 0
+        }
+      ];
+      expect(service.parse(sourceCode)).toEqual(expctedReturn);
+    });
+
+    it('Should take into account multi line comments', ()=> {
+      const sourceCode = "/*for(int i = 0; i < n; i++){\nSystem.out.print(\"Hello world\");\n}*/";
+      let expctedReturn: Block[] = [];
+      expect(service.parse(sourceCode)).toEqual(expctedReturn);
+    });
+
+    it('Should take into account single line comments', ()=> {
+      const sourceCode = "//for(int i = 0; i < n; i++){\nSystem.out.print(\"Hello world\");\n//}";
+      let expctedReturn: Block[] = [];
+      expect(service.parse(sourceCode)).toEqual(expctedReturn);
+    });
+
+  });
 });

--- a/ui/encounter/src/app/complexity-parser/complexity-parser.service.spec.ts
+++ b/ui/encounter/src/app/complexity-parser/complexity-parser.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-
 import { ComplexityParserService } from './complexity-parser.service';
+import { Block } from './block';
 
 describe('ComplexityParserService', () => {
   let service: ComplexityParserService;
@@ -10,7 +10,48 @@ describe('ComplexityParserService', () => {
     service = TestBed.inject(ComplexityParserService);
   });
 
-  it('should be created', () => {
+  it('should create component', () => {
     expect(service).toBeTruthy();
   });
+  
+  describe('Parse', ()=> {
+    it('Should return single for loop block information', ()=> {
+      const sourceCode = "for(int i = 0; i < n; i++){\nSystem.out.print(\"Hello world\");\n}";
+      let expctedReturn: Block[] = [
+        {
+          complexity: 1,
+          begLine: 1,
+          endLine: 3,
+          depth: 0
+        }
+      ];
+      expect(service.parse(sourceCode)).toEqual(expctedReturn);
+    });
+
+    it('Should return return block info from nested for loops', ()=> {
+      const sourceCode = "for(int i = 0; i < n; i++){\nfor(int j = 0; j < n; j++){\nSystem.out.print(\"Hello world\");\n}\n}";
+      let expctedReturn: Block[] = [
+        {
+          complexity: 2,
+          begLine: 1,
+          endLine: 5,
+          depth: 0
+        },
+        {
+          complexity: 1,
+          begLine: 2,
+          endLine: 4,
+          depth: 1
+        }
+      ];
+      expect(service.parse(sourceCode)).toEqual(expctedReturn);
+    });
+  });
+
+  it('Should return return block info from a block', ()=> {
+    const sourceCode = "{\nSysetm.out.println(\"Hello world\")\n}";
+    let expctedReturn: Block[] = [];
+    expect(service.parse(sourceCode)).toEqual(expctedReturn);
+  });
+
 });

--- a/ui/encounter/src/app/complexity-parser/complexity-parser.service.ts
+++ b/ui/encounter/src/app/complexity-parser/complexity-parser.service.ts
@@ -37,7 +37,6 @@ export class ComplexityParserService {
     stack.reverse()
     initialStackLength = stack.length
 
-    console.log(stack)
 
     for (let i = 0; i < initialStackLength; i++) {
 
@@ -98,7 +97,6 @@ export class ComplexityParserService {
       }
     }
 
-    console.log(blockList);
     return blockList
   }
 
@@ -133,7 +131,7 @@ export class ComplexityParserService {
 
     // Rules for other uneeded characters and whitespace
     // Ignore single line comment
-    lexer.rule(/\/\/[^\r\n]*\r?\n/, (ctx, match) => {
+    lexer.rule(/\/\/[^\r\n]*\r?\n?/, (ctx, match) => {
       ctx.ignore();
     });
 

--- a/ui/encounter/src/app/problem-creation/problem-creation.component.spec.ts
+++ b/ui/encounter/src/app/problem-creation/problem-creation.component.spec.ts
@@ -99,9 +99,55 @@ import { of } from 'rxjs';
         });
 
         describe('getTotalScore', () => {
-            it('should calculate the total score', () => {
+            it('should return the number of possible points, complexity lines + 1', () => {
                 component.complexity = ["O(N)", "O(N)"];
                 expect(component.getTotalScore()).toEqual(3);
+            });
+        });
+
+        describe('setAllToConstant', () => {
+            it('should set complexities, hints and overall complexity to be linear', () => {
+                const expectedComplexity = ["o(1)","o(1)"];
+                const expectedHints = ["The complexity is linear","The complexity is linear"]
+                component.complexity = ["O(N)", "O(N)"];
+                component.hints = ["", ""];
+                component.setAllToConstant();
+                expect(component.complexity).toEqual(expectedComplexity);
+                expect(component.hints).toEqual(expectedHints);
+                expect(component.overallComplexity).toEqual("o(1)");
+            });
+        });
+
+        describe('formatComplexity', () => {
+            it('should return o(1)', () => {
+                expect((component as any).formatComplexity(0)).toBe("o(1)");
+            });
+
+            it('should return o(n)', () => {
+                expect((component as any).formatComplexity(1)).toBe("o(n)");
+            });
+
+            it('should return o(3)', () => {
+                expect((component as any).formatComplexity(3)).toBe("o(n^3)");
+            });
+        });
+
+        describe('parse', () => {
+            it('should set overall complexity to 0(1)', () => {
+                component.sourceCode = ["int x = 5;\n", "int y = 6;"];
+                component.parse();
+                expect(component.overallComplexity).toBe("o(1)");
+            });
+
+            it('should set overall complexity to 0(n)', () => {
+                component.sourceCode = [
+                    "int x = 5;\n",
+                     "for (int i = 0; i < n; i++){\n",
+                     "System.out.print(\"hello world\");\n",
+                     "}\n"
+                    ];
+                component.parse();
+                expect(component.overallComplexity).toBe("o(n)");
             });
         });
 

--- a/ui/encounter/src/app/problem-creation/problem-creation.component.spec.ts
+++ b/ui/encounter/src/app/problem-creation/problem-creation.component.spec.ts
@@ -9,6 +9,8 @@ import { jest } from '@jest/globals';
 import { mockMatSnackBar } from '../../mocks/snack.bar.mock';
 import { of } from 'rxjs';
 import { mockSelection } from '../../mocks/selection.mock';
+import { mockMatDialog } from '../../mocks/dialog.mock';
+import { MatDialog } from '@angular/material/dialog';
 
 
 
@@ -18,6 +20,7 @@ import { mockSelection } from '../../mocks/selection.mock';
         let problemService: ProblemService;
         let router: Router;
         let _snackBar: MatSnackBar;
+        let dialog: MatDialog;
 
         beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
@@ -26,7 +29,8 @@ import { mockSelection } from '../../mocks/selection.mock';
                 providers: [
                 { provide: ProblemService, useValue: MockProblemService },
                 { provide: Router, Router},
-                { provide: MatSnackBar, useValue: mockMatSnackBar}
+                { provide: MatSnackBar, useValue: mockMatSnackBar},
+                {provide: MatDialog, useValue: mockMatDialog},
                 ]
             }).compileComponents();
         }));
@@ -36,6 +40,7 @@ import { mockSelection } from '../../mocks/selection.mock';
             problemService = TestBed.inject(ProblemService);
             router = TestBed.inject(Router);
             _snackBar = TestBed.inject(MatSnackBar);
+            dialog = TestBed.inject(MatDialog);
             component = fixture.componentInstance;
             fixture.detectChanges();
         });
@@ -120,8 +125,21 @@ import { mockSelection } from '../../mocks/selection.mock';
                 expect(snackBarOpenSpy).toHaveBeenCalled();
             });
 
-            it('should submit the problem with no problem id', ()=> {
+            it('should submit the problem after getting info from the modal', ()=> {
                 component.name = "Problem 1";
+                component.sourceCode = ["int x = 5;", "int z = 6;"];
+                component.complexity = ["O(C)","O(C)"];
+                component.overallComplexity = "O(C)";
+                const problemServiceSpy = jest.spyOn(problemService, 'addProblem').mockReturnValue(of(mockProblemArray as any));
+                const dialogSpy = jest.spyOn(dialog, 'open');
+                component.submitProblem()
+                expect(problemServiceSpy).toHaveBeenCalled();
+                expect(dialogSpy).toHaveBeenCalled();
+            });
+
+            it('should submit the problem if it has a setId', ()=> {
+                component.name = "Problem 1";
+                component.setId = 1234;
                 component.sourceCode = ["int x = 5;", "int z = 6;"];
                 component.complexity = ["O(C)","O(C)"];
                 component.overallComplexity = "O(C)";

--- a/ui/encounter/src/app/problem-creation/problem-creation.component.spec.ts
+++ b/ui/encounter/src/app/problem-creation/problem-creation.component.spec.ts
@@ -1,13 +1,14 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
-import { mockProblemArray, MockProblemService } from '../../mocks/problem.service.mock';
+import { mockProblem1, mockProblemArray, MockProblemService } from '../../mocks/problem.service.mock';
 import { AppModule } from '../app.module';
 import { ProblemService } from '../problem-service/problem.service';
 import { ProblemCreationComponent } from './problem-creation.component';
 import { jest } from '@jest/globals';
 import { mockMatSnackBar } from '../../mocks/snack.bar.mock';
 import { of } from 'rxjs';
+import { mockSelection } from '../../mocks/selection.mock';
 
 
 
@@ -38,10 +39,25 @@ import { of } from 'rxjs';
             component = fixture.componentInstance;
             fixture.detectChanges();
         });
+        
+        describe('ngOnInIt', () => {
+            it('should exist', () => {
+                expect(component).toBeDefined();
+            });
 
-        it('should exist', () => {
-            expect(component).toBeDefined();
+            it('should get problem with http request', () => {
+                component.problemId = 1;
+                component.ngOnInit();
+                expect(component.sourceCode).toEqual(mockProblem1.sourceCode);
+                expect(component.hints).toEqual(mockProblem1.hints);
+                expect(component.overallComplexity).toEqual(mockProblem1.overallComplexity);
+                expect(component.name).toEqual(mockProblem1.name);
+                expect(component.totalScore).toEqual(mockProblem1.totalScore);
+                expect(component.complexity).toEqual(mockProblem1.complexity);
+            });
         });
+
+
 
         describe('getSourceCodeFromTextInput', () => {
             it('should set the values for sourceCode, complexity, hints when codeInput is longer than 0', ()=> {
@@ -55,6 +71,22 @@ import { of } from 'rxjs';
                 let snackBarOpenSpy = jest.spyOn(_snackBar, 'open')
                 component.getSourceCodeFromTextInput();
                 expect(snackBarOpenSpy).toHaveBeenCalled();
+            });
+        });
+
+        describe('handleTab', () => {
+            it('should insert a tab when tab key is hit and stop event propagation.', ()=> {
+                let getSelectionSpy = jest.spyOn(document, 'getSelection').mockImplementation(() => (mockSelection as any))
+                let createTextNodeSpy = jest.spyOn(document, 'createTextNode')
+                const event = {
+                    target: {
+                        innerText: 'this is the before text input'
+                    },
+                    preventDefault: jest.fn()
+                }
+                component.handleTab(event)
+                expect(getSelectionSpy).toHaveBeenCalled();
+                expect(createTextNodeSpy).toHaveBeenCalled();
             });
         });
 
@@ -87,12 +119,24 @@ import { of } from 'rxjs';
                 component.submitProblem()
                 expect(snackBarOpenSpy).toHaveBeenCalled();
             });
-            it('should submit the problem', ()=> {
+
+            it('should submit the problem with no problem id', ()=> {
                 component.name = "Problem 1";
                 component.sourceCode = ["int x = 5;", "int z = 6;"];
                 component.complexity = ["O(C)","O(C)"];
                 component.overallComplexity = "O(C)";
                 let problemServiceSpy = jest.spyOn(problemService, 'addProblem').mockReturnValue(of(mockProblemArray as any))
+                component.submitProblem()
+                expect(problemServiceSpy).toHaveBeenCalled();
+            });
+
+            it('should update the problem upon submission', ()=> {
+                component.problemId = 1;
+                component.name = "Problem 1";
+                component.sourceCode = ["int x = 5;", "int z = 6;"];
+                component.complexity = ["O(C)","O(C)"];
+                component.overallComplexity = "O(C)";
+                let problemServiceSpy = jest.spyOn(problemService, 'updateProblem').mockReturnValue(of(mockProblemArray as any))
                 component.submitProblem()
                 expect(problemServiceSpy).toHaveBeenCalled();
             });

--- a/ui/encounter/src/app/problem-creation/problem-creation.component.ts
+++ b/ui/encounter/src/app/problem-creation/problem-creation.component.ts
@@ -123,6 +123,7 @@ export class ProblemCreationComponent {
         overallComplexity: this.overallComplexity,
         totalScore: this.getTotalScore(),
       }
+
       if(this.problemId){
         this.problemService.updateProblem(this.problemId, createdProblem).subscribe({
           next: () => {
@@ -137,7 +138,6 @@ export class ProblemCreationComponent {
           next: () => this.router.navigate(['/teacher-set-problems/' + this.setId])
         });
       }
-      
     }
   }
 

--- a/ui/encounter/src/mocks/dialog.mock.ts
+++ b/ui/encounter/src/mocks/dialog.mock.ts
@@ -1,0 +1,15 @@
+import { jest } from '@jest/globals';
+import { of } from 'rxjs';
+
+let mockProblemIdMap = new Map<number, number>();
+mockProblemIdMap.set(1,1);
+
+const mockDialogRef = {
+    afterClosed: jest.fn().mockReturnValue(of(mockProblemIdMap))
+}
+
+
+export const mockMatDialog = {
+    open: jest.fn().mockReturnValue(mockDialogRef),
+}
+

--- a/ui/encounter/src/mocks/problem.service.mock.ts
+++ b/ui/encounter/src/mocks/problem.service.mock.ts
@@ -5,9 +5,10 @@ export const mockProblem1 = {
     id: 1,
     name: "problem1",
     sourceCode: ["int x = 4;", "int y = 5;"],
+    hints: ["hint 1", "hint 2"],
     complexity: ["O(C)", "O(C)"],
     totalScore: 2,
-    currentScore: 2,
+    overallComplexity: "O(1)"
 }
 export const mockProblem2 = {
     id: 2,
@@ -15,7 +16,8 @@ export const mockProblem2 = {
     sourceCode: ["int x = 4;", "int y = 5;"],
     complexity: ["O(C)", "O(N)"],
     totalScore: 2,
-    currentScore: 1,
+    hints: ["hint 1", "hint 2"],
+   overallComplexity: "O(N)"
 }
 
 export const mockProblemArray = [mockProblem1, mockProblem2];
@@ -26,5 +28,7 @@ const mockProblemList = jest.fn().mockReturnValue([mockProblem1, mockProblem2])
 
 export const MockProblemService = {
     getAllProblems: mockProblemList,
-    addProblem: mockAddProblem
+    addProblem: mockAddProblem,
+    getProblemById: jest.fn().mockReturnValue(of(mockProblem1)),
+    updateProblem: jest.fn(),
 }

--- a/ui/encounter/src/mocks/selection.mock.ts
+++ b/ui/encounter/src/mocks/selection.mock.ts
@@ -1,0 +1,11 @@
+import { jest } from '@jest/globals';
+
+export const mockRange = {
+    insertNode: jest.fn(),
+    setStartAfter: jest.fn(),
+    setEndAfter: jest.fn(),
+}
+
+export const mockSelection = {
+    getRangeAt: jest.fn().mockReturnValue(mockRange)
+}


### PR DESCRIPTION
### Description
- Added coverage for problem-creation.component.ts and  complexity-parser.service.ts

### Test Steps
- Checkout the 'parser-test-coverage' branch.
- Go to `ui/encounter'.
- Run `npm run test --coverage problem-creation`, coverage for problem-creation.component.ts should be similar to the picture.
![image](https://user-images.githubusercontent.com/106398280/234683637-2d099047-102e-4b88-a2ae-3fef9e146b1a.png)

- Run `npm run test --coverage complexity-parser`, coverage should be similar to the picture.
![image](https://user-images.githubusercontent.com/106398280/234683743-e53e309e-8320-423d-9bdf-52393a65ac96.png)
