### PR TITLE
Fixed hint complexities and Removed problem count

### DIFF
--- a/ui/encounter/src/app/problem-creation/problem-creation.component.ts
+++ b/ui/encounter/src/app/problem-creation/problem-creation.component.ts
@@ -192,7 +192,25 @@ parse() {
 
     this.complexity[block.begLine - 1] = this.formatComplexity(block.complexity)
 
-    this.hints[block.begLine - 1] = block.complexity == 0 ? "The complexity is linear" : "The complexity is exponential"
+    // Set the hint
+    switch (block.complexity) {
+      case 1: {
+        this.hints[block.begLine - 1] = "The complexity is linear"
+        break;
+      }
+      case 2: {
+        this.hints[block.begLine - 1] = "The complexity is quadratic"
+        break;
+      }
+      case 3: {
+        this.hints[block.begLine - 1] = "The complexity is cubic"
+        break;
+      }
+      default: {
+        this.hints[block.begLine - 1] = "The complexity is polynomial"
+        break;
+      }
+    }
 
     if (block.complexity > maxN)
       maxN = block.complexity
@@ -203,12 +221,12 @@ parse() {
 }
 
 /**
-*   Sets all line to constant. Hints will mention linear complexiity.
+*   Sets all line to constant. Hints will mention constant complexiity.
 **/
 setAllToConstant() {
   for (let i = 0; i < this.complexity.length; i++) {
     this.complexity[i] = "o(1)";
-    this.hints[i] = "The complexity is linear";
+    this.hints[i] = "The complexity is constant";
     this.overallComplexity = "o(1)";
   }
 }

--- a/ui/encounter/src/app/teacher-problemset-page/teacher-problemset-page.component.html
+++ b/ui/encounter/src/app/teacher-problemset-page/teacher-problemset-page.component.html
@@ -56,9 +56,6 @@
                             <label>Type: {{problemset.type}}</label><br>
                         </div>
                         <div class="set-content">
-                            <label>Problems: {{problemset.problemList.length}}</label><br>
-                        </div>
-                        <div class="set-content">
                             <label>Show Date: {{problemset.showDate}}</label><br>
                         </div>
                         <div class="set-content">


### PR DESCRIPTION
- Removed the Set problem count label. Reasoning behind that can be found [here](https://github.com/am6uno/Algorithm-Run-Time-Complexity/pull/24#issuecomment-1532435850).
- Fixed the hint complexities.
  - o(1) should say constant
  - o(n) should say linear
  - o(n^2) should say quadratic
  - o(n^3) should say cubic
  - o(n^x) should say polynomial

I made no changes to the backend, so you won't have to rebuild. 
- Pull `math-notation`
- Create a problem with this file: 
  - [MultiNestedForloops.txt](https://github.com/am6uno/Algorithm-Run-Time-Complexity/files/11391708/MultiNestedForloops.txt)
- Verify that the applicable time complexities have the correct hints mentioned above